### PR TITLE
Changed deprecated call `activationEvents` to `activationCommands`

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "main": "./lib/jekyll-snippets",
   "version": "0.1.2",
   "description": "Jekyll snippets for the Atom editor",
-  "activationEvents": [
+  "activationCommands": [
     "jekyll-snippets:toggle"
   ],
   "repository": "https://github.com/jasonhodges/atom-jekyll-snippets",


### PR DESCRIPTION
Atom deprecated the `activationEvents` call to `activationCommands`. See bug report below.

Use `activationCommands` instead of `activationEvents` in your package.json
Commands should be grouped by selector as follows:
```json
  "activationCommands": {
    "atom-workspace": ["foo:bar", "foo:baz"],
    "atom-text-editor": ["foo:quux"]
  }
```
```
Package.getActivationCommands (/Applications/Atom.app/Contents/Resources/app.asar/src/package.js:808:9)
Package.hasActivationCommands (/Applications/Atom.app/Contents/Resources/app.asar/src/package.js:733:20)
<unknown> (/Applications/Atom.app/Contents/Resources/app.asar/src/package.js:185:24)
Package.measure (/Applications/Atom.app/Contents/Resources/app.asar/src/package.js:163:15)
Package.load (/Applications/Atom.app/Contents/Resources/app.asar/src/package.js:177:12)
PackageManager.loadPackage (/Applications/Atom.app/Contents/Resources/app.asar/src/package-manager.js:355:14)
```